### PR TITLE
GitHub actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1425,31 +1425,6 @@ jobs:
         run: |
           ./script/check_dirty
 
-  coverage-full:
-    name: Upload test coverage to Codecov (full suite)
-    if: needs.info.outputs.skip_coverage != 'true'
-    runs-on: ubuntu-24.04
-    needs:
-      - info
-      - pytest-full
-      - pytest-postgres
-      - pytest-mariadb
-    timeout-minutes: 10
-    steps:
-      - name: Check out code from GitHub
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - name: Download all coverage artifacts
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
-        with:
-          pattern: coverage-*
-      - name: Upload coverage to Codecov
-        if: needs.info.outputs.test_full_suite == 'true'
-        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
-        with:
-          fail_ci_if_error: true
-          flags: full-suite
-          token: ${{ secrets.CODECOV_TOKEN }}
-
   pytest-partial:
     runs-on: ubuntu-24.04
     if: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1612,28 +1612,3 @@ jobs:
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
-
-  # upload-test-results:
-  #   name: Upload test results to Codecov
-  #   # codecov/test-results-action currently doesn't support tokenless uploads
-  #   # therefore we can't run it on forks
-  #   if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && needs.info.outputs.skip_coverage != 'true' && !cancelled() }}
-  #   runs-on: ubuntu-24.04
-  #   needs:
-  #     - info
-  #     - pytest-partial
-  #     - pytest-full
-  #     - pytest-postgres
-  #     - pytest-mariadb
-  #   timeout-minutes: 10
-  #   steps:
-  #     - name: Download all coverage artifacts
-  #       uses: actions/download-artifact@v5.0.0
-  #       with:
-  #         pattern: test-results-*
-  #     - name: Upload test results to Codecov
-  #       uses: codecov/test-results-action@v1
-  #       with:
-  #         fail_ci_if_error: true
-  #         verbose: true
-  #         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1590,25 +1590,3 @@ jobs:
       - name: Check dirty
         run: |
           ./script/check_dirty
-
-  coverage-partial:
-    name: Upload test coverage to Codecov (partial suite)
-    if: needs.info.outputs.skip_coverage != 'true'
-    runs-on: ubuntu-24.04
-    needs:
-      - info
-      - pytest-partial
-    timeout-minutes: 10
-    steps:
-      - name: Check out code from GitHub
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - name: Download all coverage artifacts
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
-        with:
-          pattern: coverage-*
-      - name: Upload coverage to Codecov
-        if: needs.info.outputs.test_full_suite == 'false'
-        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
-        with:
-          fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1613,27 +1613,27 @@ jobs:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  upload-test-results:
-    name: Upload test results to Codecov
-    # codecov/test-results-action currently doesn't support tokenless uploads
-    # therefore we can't run it on forks
-    if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && needs.info.outputs.skip_coverage != 'true' && !cancelled() }}
-    runs-on: ubuntu-24.04
-    needs:
-      - info
-      - pytest-partial
-      - pytest-full
-      - pytest-postgres
-      - pytest-mariadb
-    timeout-minutes: 10
-    steps:
-      - name: Download all coverage artifacts
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
-        with:
-          pattern: test-results-*
-      - name: Upload test results to Codecov
-        uses: codecov/test-results-action@47f89e9acb64b76debcd5ea40642d25a4adced9f # v1.1.1
-        with:
-          fail_ci_if_error: true
-          verbose: true
-          token: ${{ secrets.CODECOV_TOKEN }}
+  # upload-test-results:
+  #   name: Upload test results to Codecov
+  #   # codecov/test-results-action currently doesn't support tokenless uploads
+  #   # therefore we can't run it on forks
+  #   if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && needs.info.outputs.skip_coverage != 'true' && !cancelled() }}
+  #   runs-on: ubuntu-24.04
+  #   needs:
+  #     - info
+  #     - pytest-partial
+  #     - pytest-full
+  #     - pytest-postgres
+  #     - pytest-mariadb
+  #   timeout-minutes: 10
+  #   steps:
+  #     - name: Download all coverage artifacts
+  #       uses: actions/download-artifact@v5.0.0
+  #       with:
+  #         pattern: test-results-*
+  #     - name: Upload test results to Codecov
+  #       uses: codecov/test-results-action@v1
+  #       with:
+  #         fail_ci_if_error: true
+  #         verbose: true
+  #         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Make stupid changes to get github Action to run the test suite for me. 
In particular I removed several sections that uploaded coverage values to github. This will not work as this is a forked repo and I also can't be bothered to figure out how to set the secret.