### PR TITLE
Resolved one issue

### DIFF
--- a/homeassistant/components/icloud/services.py
+++ b/homeassistant/components/icloud/services.py
@@ -102,7 +102,7 @@ def update_account(service: ServiceCall) -> None:
 
 def _get_account(hass: HomeAssistant, account_identifier: str) -> IcloudAccount:
     if account_identifier is None:
-        return None
+        raise ValueError("Account_identifier is None")
 
     entry: IcloudConfigEntry
     for entry in hass.config_entries.async_loaded_entries(DOMAIN):


### PR DESCRIPTION
Miran Ismail

Motivation: Even though we got a return type, the function could return None. I fixed this to have a return type that is always the same type

Relevance: Dose not really do much, But this is better for maintainability and consistency