### PR TITLE
Add type hinting for the data object

### DIFF
--- a/homeassistant/components/lidarr/__init__.py
+++ b/homeassistant/components/lidarr/__init__.py
@@ -39,7 +39,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: LidarrConfigEntry) -> bo
         session=async_get_clientsession(hass, host_configuration.verify_ssl),
         request_timeout=60,
     )
-    data = LidarrData(
+    data: LidarrData = LidarrData(
         disk_space=DiskSpaceDataUpdateCoordinator(
             hass, entry, host_configuration, lidarr
         ),

--- a/homeassistant/components/lidarr/__init__.py
+++ b/homeassistant/components/lidarr/__init__.py
@@ -48,7 +48,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: LidarrConfigEntry) -> bo
         wanted=WantedDataUpdateCoordinator(hass, entry, host_configuration, lidarr),
         albums=AlbumsDataUpdateCoordinator(hass, entry, host_configuration, lidarr),
     )
-    for field in fields(data):
+    for field in fields(LidarrData):
         coordinator = getattr(data, field.name)
         await coordinator.async_config_entry_first_refresh()
     device_registry = dr.async_get(hass)


### PR DESCRIPTION
Sofia Blom
This particular issue received a 10 of 18 possible score from our prioritization criteria, making it an issue but not a top priority. 
Sonar Cube Claims that the function fields expects a different type. According to the doc string attached to the function it expect ether a dataclass or an instance of a dataclass. 

Seems to me that it's what I have given it. Making this PR to see if Sonar Cube think's this will fix the issue