### PR TITLE
remove unused hex_color variable from RGB and RGBW light classes

### DIFF
--- a/homeassistant/components/mysensors/light.py
+++ b/homeassistant/components/mysensors/light.py
@@ -147,7 +147,6 @@ class MySensorsLightRGB(MySensorsLight):
 
     def _turn_on_rgb(self, **kwargs: Any) -> None:
         """Turn on RGB child device."""
-        hex_color = self._values.get(self.value_type)
         new_rgb: tuple[int, int, int] | None = kwargs.get(ATTR_RGB_COLOR)
         if new_rgb is None:
             return
@@ -188,7 +187,6 @@ class MySensorsLightRGBW(MySensorsLightRGB):
 
     def _turn_on_rgbw(self, **kwargs: Any) -> None:
         """Turn on RGBW child device."""
-        hex_color = self._values.get(self.value_type)
         new_rgbw: tuple[int, int, int, int] | None = kwargs.get(ATTR_RGBW_COLOR)
         if new_rgbw is None:
             return


### PR DESCRIPTION
**Simon Ljung**

## Motivation (why this matters)
This removes a dead assignment to the local variable `hex_color` at line 150 and 191. Keeping unused locals harms maintainability by:

- Increasing cognitive load for readers who try to understand how `hex_color` affects control flow when it actually does not.  
- Risking future bugs if someone later assumes the variable is authoritative and “updates” it without effect.  
- Adding noise that blocks static analysis and code search from clearly showing the real data flow in `_turn_on_rgb` and `_turn_on_rgbw`.

The issue has been present for over a year without being resolved, so this PR addresses it directly.
