### PR TITLE
Use frontend local repo

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,9 @@
   "postCreateCommand": "git config --global --add safe.directory ${containerWorkspaceFolder} && script/setup",
   "postStartCommand": "script/bootstrap",
   "containerEnv": {
-    "PYTHONASYNCIODEBUG": "1"
+    "PYTHONASYNCIODEBUG": "1",
+    "HASS_FRONTEND_DEV": "1",
+    "HASS_FRONTEND_REPO": "/workspaces/home-assistant-frontend-ht25"
   },
   "features": {
     // Node feature required for Claude Code until fixed https://github.com/anthropics/devcontainer-features/issues/28
@@ -20,6 +22,9 @@
     "GIT_EDITOR=code --wait",
     "--security-opt",
     "label=disable"
+  ],
+  "mounts": [
+    "source=${localWorkspaceFolder}/../home-assistant-frontend-ht25,target=/workspaces/frontend,type=bind"
   ],
   "customizations": {
     "vscode": {

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -38,7 +38,7 @@ RUN uv python install 3.13.2
 
 USER vscode
 ENV VIRTUAL_ENV="/home/vscode/.local/ha-venv"
-RUN uv venv $VIRTUAL_ENV
+RUN uv venv --python 3.13.2 $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 WORKDIR /tmp


### PR DESCRIPTION
This pull request updates the development container configuration and Dockerfile to improve frontend development workflows and ensure compatibility with Python 3.13.2. The main changes include new environment variables and volume mounts for frontend development, and specifying the Python version for the virtual environment.

Development container improvements for frontend development:

* Added `HASS_FRONTEND_DEV` and `HASS_FRONTEND_REPO` environment variables to the container environment in `.devcontainer/devcontainer.json` to enable and specify the path for local frontend development.
* Added a bind mount in `.devcontainer/devcontainer.json` to mount the local frontend repository into the container at `/workspaces/frontend`, making it easier to develop and test frontend changes.

Python environment update:

* Updated `Dockerfile.dev` to specify Python version 3.13.2 when creating the virtual environment, ensuring consistency and compatibility.