### PR TITLE
Kalles implementation of sorting by category and tests

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,9 @@
   "postCreateCommand": "git config --global --add safe.directory ${containerWorkspaceFolder} && script/setup",
   "postStartCommand": "script/bootstrap",
   "containerEnv": {
-    "PYTHONASYNCIODEBUG": "1"
+    "PYTHONASYNCIODEBUG": "1",
+    "HASS_FRONTEND_DEV": "1",
+    "HASS_FRONTEND_REPO": "/workspaces/home-assistant-frontend-ht25"
   },
   "features": {
     // Node feature required for Claude Code until fixed https://github.com/anthropics/devcontainer-features/issues/28
@@ -20,6 +22,9 @@
     "GIT_EDITOR=code --wait",
     "--security-opt",
     "label=disable"
+  ],
+  "mounts": [
+    "source=${localWorkspaceFolder}/../home-assistant-frontend-ht25,target=/workspaces/frontend,type=bind"
   ],
   "customizations": {
     "vscode": {

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -38,7 +38,7 @@ RUN uv python install 3.13.2
 
 USER vscode
 ENV VIRTUAL_ENV="/home/vscode/.local/ha-venv"
-RUN uv venv $VIRTUAL_ENV
+RUN uv venv --python 3.13.2 $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 WORKDIR /tmp

--- a/homeassistant/components/shopping_list/__init__.py
+++ b/homeassistant/components/shopping_list/__init__.py
@@ -43,13 +43,22 @@ ATTR_COMPLETE = "complete"
 
 _LOGGER = logging.getLogger(__name__)
 CONFIG_SCHEMA = vol.Schema({DOMAIN: {}}, extra=vol.ALLOW_EXTRA)
-ITEM_UPDATE_SCHEMA = vol.Schema({ATTR_COMPLETE: bool, ATTR_NAME: str})
+ITEM_UPDATE_SCHEMA = vol.Schema(
+    {
+        vol.Optional(ATTR_COMPLETE): bool,
+        vol.Optional(ATTR_NAME): str,
+        vol.Optional("description"): str,
+    }
+)
 PERSISTENCE = ".shopping_list.json"
 
 SERVICE_ITEM_SCHEMA = vol.Schema({vol.Required(ATTR_NAME): cv.string})
 SERVICE_LIST_SCHEMA = vol.Schema({})
 SERVICE_SORT_SCHEMA = vol.Schema(
-    {vol.Optional(ATTR_REVERSE, default=DEFAULT_REVERSE): bool}
+    {
+        vol.Optional(ATTR_REVERSE, default=DEFAULT_REVERSE): bool,
+        vol.Optional("by", default="name"): vol.In(["name", "description"]),
+    }
 )
 
 
@@ -122,8 +131,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         await data.async_clear_completed()
 
     async def sort_list_service(call: ServiceCall) -> None:
-        """Sort all items by name."""
-        await data.async_sort(call.data[ATTR_REVERSE])
+        """Sort all items by name or description."""
+        await data.async_sort(call.data[ATTR_REVERSE], call.data["by"])
 
     data = hass.data[DOMAIN] = ShoppingData(hass)
     await data.async_load()
@@ -199,14 +208,20 @@ class ShoppingData:
         self._listeners: list[Callable[[], None]] = []
 
     async def async_add(
-        self, name: str | None, complete: bool = False, context: Context | None = None
+        self,
+        name: str | None,
+        complete: bool = False,
+        description: str = "",
+        context: Context | None = None,
     ) -> dict[str, JsonValueType]:
         """Add a shopping list item."""
         item: dict[str, JsonValueType] = {
             "name": name,
             "id": uuid.uuid4().hex,
             "complete": complete,
+            "description": description,
         }
+
         self.items.append(item)
         await self.hass.async_add_executor_job(self.save)
         self._async_notify()
@@ -384,15 +399,22 @@ class ShoppingData:
         )
 
     async def async_sort(
-        self, reverse: bool = False, context: Context | None = None
+        self,
+        reverse: bool = False,
+        by: str = "name",
+        context: Context | None = None,
     ) -> None:
-        """Sort items by name."""
-        self.items = sorted(self.items, key=lambda item: item["name"], reverse=reverse)  # type: ignore[arg-type,return-value]
-        self.hass.async_add_executor_job(self.save)
+        """Sort items by name or description."""
+        self.items = sorted(
+            self.items,
+            key=lambda item: str(item.get(by, "") or "").lower(),
+            reverse=reverse,
+        )
+        await self.hass.async_add_executor_job(self.save)
         self._async_notify()
         self.hass.bus.async_fire(
             EVENT_SHOPPING_LIST_UPDATED,
-            {"action": "sorted"},
+            {"action": f"sorted_by_{by}"},
             context=context,
         )
 
@@ -465,11 +487,20 @@ class CreateShoppingListItemView(http.HomeAssistantView):
     url = "/api/shopping_list/item"
     name = "api:shopping_list:item"
 
-    @RequestDataValidator(vol.Schema({vol.Required("name"): str}))
+    @RequestDataValidator(
+        vol.Schema(
+            {
+                vol.Required("name"): str,
+                vol.Optional("description", default=""): str,
+            }
+        )
+    )
     async def post(self, request: web.Request, data: dict[str, str]) -> web.Response:
         """Create a new shopping list item."""
         hass = request.app[http.KEY_HASS]
-        item = await hass.data[DOMAIN].async_add(data["name"])
+        item = await hass.data[DOMAIN].async_add(
+            data["name"], description=data.get("description", "")
+        )
         return self.json(item)
 
 
@@ -546,6 +577,7 @@ async def websocket_handle_remove(
         vol.Required("item_id"): str,
         vol.Optional("name"): str,
         vol.Optional("complete"): bool,
+        vol.Optional("description"): str,
     }
 )
 @websocket_api.async_response

--- a/homeassistant/components/shopping_list/todo.py
+++ b/homeassistant/components/shopping_list/todo.py
@@ -39,6 +39,7 @@ class ShoppingTodoListEntity(TodoListEntity):
         | TodoListEntityFeature.DELETE_TODO_ITEM
         | TodoListEntityFeature.UPDATE_TODO_ITEM
         | TodoListEntityFeature.MOVE_TODO_ITEM
+        | TodoListEntityFeature.SET_DESCRIPTION_ON_ITEM
     )
 
     def __init__(self, data: ShoppingData, unique_id: str) -> None:
@@ -49,7 +50,9 @@ class ShoppingTodoListEntity(TodoListEntity):
     async def async_create_todo_item(self, item: TodoItem) -> None:
         """Add an item to the To-do list."""
         await self._data.async_add(
-            item.summary, complete=(item.status == TodoItemStatus.COMPLETED)
+            item.summary,
+            description=item.description or "",
+            complete=(item.status == TodoItemStatus.COMPLETED),
         )
 
     async def async_update_todo_item(self, item: TodoItem) -> None:
@@ -57,6 +60,7 @@ class ShoppingTodoListEntity(TodoListEntity):
         data = {
             "name": item.summary,
             "complete": item.status == TodoItemStatus.COMPLETED,
+            "description": item.description or "",
         }
         try:
             await self._data.async_update(item.uid, data)
@@ -100,6 +104,7 @@ class ShoppingTodoListEntity(TodoListEntity):
             results.append(
                 TodoItem(
                     summary=cast(str, item["name"]),
+                    description=str(item.get("description") or ""),
                     uid=cast(str, item["id"]),
                     status=status,
                 )

--- a/tests/components/shopping_list/test_init.py
+++ b/tests/components/shopping_list/test_init.py
@@ -223,7 +223,7 @@ async def test_deprecated_api_update(
     assert resp.status == HTTPStatus.OK
     assert len(events) == 1
     data = await resp.json()
-    assert data == {"id": beer_id, "name": "soda", "complete": False}
+    assert data == {"id": beer_id, "name": "soda", "complete": False, "description": ""}
 
     resp = await client.post(
         f"/api/shopping_list/item/{wine_id}", json={"complete": True}
@@ -232,11 +232,11 @@ async def test_deprecated_api_update(
     assert resp.status == HTTPStatus.OK
     assert len(events) == 2
     data = await resp.json()
-    assert data == {"id": wine_id, "name": "wine", "complete": True}
+    assert data == {"id": wine_id, "name": "wine", "complete": True, "description": ""}
 
     beer, wine = hass.data["shopping_list"].items
-    assert beer == {"id": beer_id, "name": "soda", "complete": False}
-    assert wine == {"id": wine_id, "name": "wine", "complete": True}
+    assert beer == {"id": beer_id, "name": "soda", "complete": False, "description": ""}
+    assert wine == {"id": wine_id, "name": "wine", "complete": True, "description": ""}
 
 
 async def test_ws_update_item(
@@ -265,7 +265,7 @@ async def test_ws_update_item(
     msg = await client.receive_json()
     assert msg["success"] is True
     data = msg["result"]
-    assert data == {"id": beer_id, "name": "soda", "complete": False}
+    assert data == {"id": beer_id, "name": "soda", "complete": False, "description": ""}
     assert len(events) == 1
 
     await client.send_json(
@@ -279,12 +279,12 @@ async def test_ws_update_item(
     msg = await client.receive_json()
     assert msg["success"] is True
     data = msg["result"]
-    assert data == {"id": wine_id, "name": "wine", "complete": True}
+    assert data == {"id": wine_id, "name": "wine", "complete": True, "description": ""}
     assert len(events) == 2
 
     beer, wine = hass.data["shopping_list"].items
-    assert beer == {"id": beer_id, "name": "soda", "complete": False}
-    assert wine == {"id": wine_id, "name": "wine", "complete": True}
+    assert beer == {"id": beer_id, "name": "soda", "complete": False, "description": ""}
+    assert wine == {"id": wine_id, "name": "wine", "complete": True, "description": ""}
 
 
 async def test_api_update_fails(
@@ -370,7 +370,12 @@ async def test_deprecated_api_clear_completed(
     items = hass.data["shopping_list"].items
     assert len(items) == 1
 
-    assert items[0] == {"id": wine_id, "name": "wine", "complete": False}
+    assert items[0] == {
+        "id": wine_id,
+        "name": "wine",
+        "complete": False,
+        "description": "",
+    }
 
 
 async def test_ws_clear_items(
@@ -404,7 +409,12 @@ async def test_ws_clear_items(
     assert msg["success"] is True
     items = hass.data["shopping_list"].items
     assert len(items) == 1
-    assert items[0] == {"id": wine_id, "name": "wine", "complete": False}
+    assert items[0] == {
+        "id": wine_id,
+        "name": "wine",
+        "complete": False,
+        "description": "",
+    }
     assert len(events) == 2
 
 
@@ -555,16 +565,19 @@ async def test_ws_reorder_items(
         "id": wine_id,
         "name": "wine",
         "complete": False,
+        "description": "",
     }
     assert hass.data["shopping_list"].items[1] == {
         "id": apple_id,
         "name": "apple",
         "complete": False,
+        "description": "",
     }
     assert hass.data["shopping_list"].items[2] == {
         "id": beer_id,
         "name": "beer",
         "complete": False,
+        "description": "",
     }
 
     # Mark wine as completed.
@@ -593,16 +606,19 @@ async def test_ws_reorder_items(
         "id": apple_id,
         "name": "apple",
         "complete": False,
+        "description": "",
     }
     assert hass.data["shopping_list"].items[1] == {
         "id": beer_id,
         "name": "beer",
         "complete": False,
+        "description": "",
     }
     assert hass.data["shopping_list"].items[2] == {
         "id": wine_id,
         "name": "wine",
         "complete": True,
+        "description": "",
     }
 
 
@@ -766,3 +782,57 @@ async def test_sort_list_service(hass: HomeAssistant, sl_setup) -> None:
     assert hass.data[DOMAIN].items[1][ATTR_NAME] == "ddd"
     assert hass.data[DOMAIN].items[2][ATTR_NAME] == "aaa"
     assert len(events) == 2
+
+
+async def test_service_sort_by_name_and_description(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator, sl_setup
+) -> None:
+    """Test the shopping_list.sort service sorts correctly by name and description."""
+    client = await hass_client()
+
+    # Add items with both names and descriptions
+    await client.post(
+        "/api/shopping_list/item", json={"name": "banana", "description": "yellow"}
+    )
+    await client.post(
+        "/api/shopping_list/item", json={"name": "apple", "description": "green"}
+    )
+    await client.post(
+        "/api/shopping_list/item", json={"name": "carrot", "description": "orange"}
+    )
+
+    events = async_capture_events(hass, EVENT_SHOPPING_LIST_UPDATED)
+
+    # Sort by name (alphabetical)
+    await hass.services.async_call(DOMAIN, "sort", {"by": "name"}, blocking=True)
+    assert len(events) >= 1
+    assert events[-1].data["action"] == "sorted_by_name"
+
+    items = hass.data[DOMAIN].items
+    names = [item["name"] for item in items]
+    assert names == ["apple", "banana", "carrot"]
+
+    # Sort by name in reverse
+    await hass.services.async_call(
+        DOMAIN, "sort", {"by": "name", "reverse": True}, blocking=True
+    )
+    assert events[-1].data["action"] == "sorted_by_name"
+    items = hass.data[DOMAIN].items
+    names = [item["name"] for item in items]
+    assert names == ["carrot", "banana", "apple"]
+
+    # Sort by description
+    await hass.services.async_call(DOMAIN, "sort", {"by": "description"}, blocking=True)
+    assert events[-1].data["action"] == "sorted_by_description"
+    items = hass.data[DOMAIN].items
+    descriptions = [item["description"] for item in items]
+    assert descriptions == ["green", "orange", "yellow"]
+
+    # Sort by description in reverse
+    await hass.services.async_call(
+        DOMAIN, "sort", {"by": "description", "reverse": True}, blocking=True
+    )
+    assert events[-1].data["action"] == "sorted_by_description"
+    items = hass.data[DOMAIN].items
+    descriptions = [item["description"] for item in items]
+    assert descriptions == ["yellow", "orange", "green"]


### PR DESCRIPTION
Kalle Engblom

How I addressed the issue (Implementation)

The original implementation of the shopping_list.sort service could only sort by item name. What I did was to allow to also be sorted by their category (description) 

Additionally, tests were added to confirm that sorting by both "name" and "description" works as expected and produces consistent results even when data varies in structure.

Testing

All tests in the shopping_list module pass successfully (pytest tests/components/shopping_list), and new tests were added to validate sorting by multiple criteria (by="name" and by="description").

