### PR TITLE
Remove async variable on test_recommendations

### DIFF
--- a/tests/components/shopping_list/test_recommendations.py
+++ b/tests/components/shopping_list/test_recommendations.py
@@ -4,7 +4,7 @@ from homeassistant.components.shopping_list.recommendations import ShoppingRecom
 from homeassistant.core import HomeAssistant
 
 
-async def test_observe_and_suggest_basic(hass: HomeAssistant) -> None:
+def test_observe_and_suggest_basic(hass: HomeAssistant) -> None:
     """Test that observing items creates expected suggestions."""
     rec = ShoppingRecommender()
     rec.observe_list(["milk", "bread", "eggs"])
@@ -15,14 +15,14 @@ async def test_observe_and_suggest_basic(hass: HomeAssistant) -> None:
     assert len(suggestions) <= 3
 
 
-async def test_suggest_returns_empty_for_unknown_item(hass: HomeAssistant) -> None:
+def test_suggest_returns_empty_for_unknown_item(hass: HomeAssistant) -> None:
     """Test that unknown items return an empty list."""
     rec = ShoppingRecommender()
     result = rec.suggest("nonexistent")
     assert result == []
 
 
-async def test_cooccurrence_counts_increase(hass: HomeAssistant) -> None:
+def test_cooccurrence_counts_increase(hass: HomeAssistant) -> None:
     """Test that repeated co-occurrences increase the stored counts."""
     rec = ShoppingRecommender()
     rec.observe_list(["milk", "bread"])


### PR DESCRIPTION
This pull request updates the test suite for the shopping list recommendations component by converting all asynchronous test functions to synchronous ones. This change improves test reliability and aligns with the synchronous nature of the tested code.

Testing improvements:

* Changed all test functions in `tests/components/shopping_list/test_recommendations.py` from `async def` to regular `def`, ensuring compatibility with the synchronous implementation of `ShoppingRecommender`. [[1]](diffhunk://#diff-7324ec76023a68c52356c82e9fdc3f4e59d5a71b065f1e2612ad1e4caa72c793L7-R7) [[2]](diffhunk://#diff-7324ec76023a68c52356c82e9fdc3f4e59d5a71b065f1e2612ad1e4caa72c793L18-R25)